### PR TITLE
feat: forward chat reactions to community members

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@dcl/eslint-config": "^2.4.3",
-    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-17480095113.commit-df23824.tgz",
+    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-22997207545.commit-32bf1fb.tgz",
     "@livekit/rtc-node": "^0.13.14",
     "@well-known-components/env-config-provider": "^1.2.0",
     "@well-known-components/http-server": "^2.1.0",

--- a/src/logic/message-routing.ts
+++ b/src/logic/message-routing.ts
@@ -48,7 +48,7 @@ export async function createMessageRouting(
           throw new Error('No local participant available')
         }
 
-        if (packet.message?.$case !== 'chat') {
+        if (packet.message?.$case !== 'chat' && packet.message?.$case !== 'chatReaction') {
           throw new Error('Invalid message type')
         }
 
@@ -78,15 +78,14 @@ export async function createMessageRouting(
           batchSize: PUBLISH_BATCH_SIZE
         })
 
+        const innerMessage =
+          packet.message.$case === 'chat'
+            ? { $case: 'chat' as const, chat: { ...packet.message.chat, forwardedFrom: from } }
+            : { $case: 'chatReaction' as const, chatReaction: { ...packet.message.chatReaction, address: from } }
+
         const encodedPayload = Packet.encode({
           ...packet,
-          message: {
-            ...packet.message,
-            chat: {
-              ...packet.message.chat,
-              forwardedFrom: from
-            }
-          }
+          message: innerMessage
         }).finish()
 
         for (let i = 0; i < batches.length; i++) {

--- a/test/unit/message-routing.spec.ts
+++ b/test/unit/message-routing.spec.ts
@@ -9,7 +9,7 @@ import { IDatabaseComponent } from '../../src/adapters/db'
 import { createTestLogsComponent } from '../mocks/components'
 import { MockRoom, mockRoom } from '../mocks/livekit'
 import { metricDeclarations } from '../../src/metrics'
-import { Chat, Packet } from '@dcl/protocol/out-js/decentraland/kernel/comms/rfc4/comms.gen'
+import { Chat, ChatReaction, Packet } from '@dcl/protocol/out-js/decentraland/kernel/comms/rfc4/comms.gen'
 
 describe('when handling message routing', () => {
   let messageRouting: IMessageRoutingComponent
@@ -39,13 +39,38 @@ describe('when handling message routing', () => {
   })
 
   describe('when transforming Livekit data', () => {
-    it('should transform Livekit data into an IncomingMessage', () => {
+    it('should transform Livekit chat data into an IncomingMessage', () => {
       const packet = Packet.create({
         message: {
           $case: 'chat',
           chat: {
             message: 'Hello world',
             timestamp: Date.now()
+          }
+        }
+      })
+      const payload = Packet.encode(packet).finish()
+      const participant = { identity: 'test-user' }
+      const kind = 1 // KIND_LOSSY
+      const topic = 'community:test-community'
+
+      const message = fromLivekitReceivedData(payload, participant as any, kind, topic)
+
+      expect(message).toEqual({
+        packet,
+        from: 'test-user',
+        communityId: 'test-community'
+      })
+    })
+
+    it('should transform Livekit chatReaction data into an IncomingMessage', () => {
+      const packet = Packet.create({
+        message: {
+          $case: 'chatReaction',
+          chatReaction: {
+            emojiIndex: 1,
+            messageId: 'msg-123',
+            address: '0xSenderAddress'
           }
         }
       })
@@ -298,6 +323,80 @@ describe('when handling message routing', () => {
 
         expect(mockRoom.localParticipant.publishData).not.toHaveBeenCalled()
         expect(mockMetrics.startTimer).toHaveBeenCalledWith('message_delivery_latency')
+        expect(mockMetrics.increment).toHaveBeenCalledWith('message_delivery_total', { outcome: 'failed' })
+        expect(mockTimer.end).toHaveBeenCalled()
+      })
+    })
+
+    describe('when routing chatReaction messages', () => {
+      let chatReaction: ChatReaction
+      let packet: Packet
+
+      beforeEach(() => {
+        mockDB.belongsToCommunity.mockResolvedValue(true)
+        mockDB.getCommunityMembers.mockResolvedValue(['user1', 'user2'])
+
+        chatReaction = ChatReaction.create({
+          emojiIndex: 1,
+          messageId: 'msg-123',
+          address: '0xOriginalAddress'
+        })
+
+        packet = Packet.create({
+          message: {
+            $case: 'chatReaction',
+            chatReaction
+          }
+        })
+      })
+
+      it('should route chatReaction and overwrite address with verified sender identity', async () => {
+        const message: IncomingMessage = {
+          packet,
+          from: 'test-user',
+          communityId: 'test-community'
+        }
+
+        await messageRouting.routeMessage(mockRoom as any, message)
+
+        expect(mockDB.getCommunityMembers).toHaveBeenCalledWith('test-community', {
+          exclude: ['test-user']
+        })
+
+        const expectedEncodedPayload = Packet.encode({
+          ...packet,
+          message: {
+            $case: 'chatReaction',
+            chatReaction: {
+              ...chatReaction,
+              address: 'test-user'
+            }
+          }
+        }).finish()
+
+        expect(mockRoom.localParticipant.publishData).toHaveBeenCalledWith(expectedEncodedPayload, {
+          destination_identities: ['user1', 'user2'],
+          reliable: true,
+          topic: 'community:test-community'
+        })
+
+        expect(mockMetrics.increment).toHaveBeenCalledWith('message_delivery_total', { outcome: 'delivered' })
+        expect(mockTimer.end).toHaveBeenCalled()
+      })
+
+      it('should reject chatReaction from non-member', async () => {
+        mockDB.belongsToCommunity.mockResolvedValue(false)
+
+        const message: IncomingMessage = {
+          packet,
+          from: 'test-user',
+          communityId: 'test-community'
+        }
+
+        await messageRouting.routeMessage(mockRoom as any, message)
+
+        expect(mockDB.belongsToCommunity).toHaveBeenCalledWith('test-community', 'test-user')
+        expect(mockRoom.localParticipant.publishData).not.toHaveBeenCalled()
         expect(mockMetrics.increment).toHaveBeenCalledWith('message_delivery_total', { outcome: 'failed' })
         expect(mockTimer.end).toHaveBeenCalled()
       })

--- a/yarn.lock
+++ b/yarn.lock
@@ -302,9 +302,9 @@
     eslint-plugin-prettier "^5.1.3"
     prettier "^3.3.2"
 
-"@dcl/protocol@https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-17480095113.commit-df23824.tgz":
-  version "1.0.0-17480095113.commit-df23824"
-  resolved "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-17480095113.commit-df23824.tgz#2c286c9d1af1fc46837100c8c02bcaa0bb2885cf"
+"@dcl/protocol@https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-22997207545.commit-32bf1fb.tgz":
+  version "1.0.0-22997207545.commit-32bf1fb"
+  resolved "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-22997207545.commit-32bf1fb.tgz#a87e26f49b30180bec23ca2010669f2c23c8c8a5"
   dependencies:
     "@dcl/ts-proto" "1.154.0"
     protobufjs "7.2.4"


### PR DESCRIPTION
## Changes

- **Message routing**: Extended message routing logic to handle `chatReaction` messages in addition to `chat` messages
  - Modified validation to accept both message types
  - Updated message transformation to forward `chatReaction` with verified sender address
  
- **Protocol dependency**: Updated `@dcl/protocol` to include support for chat reactions

- **Tests**: Added comprehensive test coverage for chat reaction routing
  - Validates transformation of chat reaction data
  - Ensures address field is overwritten with verified sender identity
  - Tests rejection of reactions from non-community members
  - Tests successful delivery to community members

## Impact

Community members can now forward emoji reactions on chat messages, with proper verification and routing to all community participants.