### PR TITLE
fix: guard publishData against non-connected Room

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   },
   "dependencies": {
     "@dcl/eslint-config": "^2.4.3",
-    "@dcl/protocol": "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-22997207545.commit-32bf1fb.tgz",
-    "@livekit/rtc-node": "^0.13.14",
+    "@dcl/protocol": "experimental",
+    "@livekit/rtc-node": "^0.13.27",
     "@well-known-components/env-config-provider": "^1.2.0",
     "@well-known-components/http-server": "^2.1.0",
     "@well-known-components/interfaces": "^1.5.1",

--- a/src/logic/message-routing.ts
+++ b/src/logic/message-routing.ts
@@ -52,6 +52,10 @@ export async function createMessageRouting(
           throw new Error('Invalid message type')
         }
 
+        if (room.connectionState !== ConnectionState.CONN_CONNECTED) {
+          throw new Error(`Room not connected (state=${room.connectionState}); aborting routing`)
+        }
+
         const isMember = await db.belongsToCommunity(communityId, from)
         if (!isMember) {
           throw new Error(`User ${from} is not a member of community ${communityId}, skipping message routing`)

--- a/src/logic/message-routing.ts
+++ b/src/logic/message-routing.ts
@@ -1,5 +1,5 @@
 import { AppComponents } from '../types'
-import { DataPacketKind, RemoteParticipant, Room } from '@livekit/rtc-node'
+import { ConnectionState, DataPacketKind, RemoteParticipant, Room } from '@livekit/rtc-node'
 import { Packet } from '@dcl/protocol/out-js/decentraland/kernel/comms/rfc4/comms.gen'
 
 export type IncomingMessage = {
@@ -90,6 +90,12 @@ export async function createMessageRouting(
 
         for (let i = 0; i < batches.length; i++) {
           const batch = batches[i]
+          // Guard against publishing on a Room whose native state is being torn down
+          // by a concurrent reconnect — calling publishData on a disconnected/reconnecting
+          // Room can SIGSEGV inside @livekit/rtc-node.
+          if (room.connectionState !== ConnectionState.CONN_CONNECTED) {
+            throw new Error(`Room not connected (state=${room.connectionState}); aborting publish`)
+          }
           try {
             await room.localParticipant.publishData(encodedPayload, {
               destination_identities: batch,

--- a/test/unit/message-routing.spec.ts
+++ b/test/unit/message-routing.spec.ts
@@ -301,42 +301,51 @@ describe('when handling message routing', () => {
       })
     })
 
-    describe('and the room becomes disconnected before publish', () => {
-      beforeEach(() => {
-        mockDB.belongsToCommunity.mockResolvedValue(true)
-        mockDB.getCommunityMembers.mockResolvedValue(['user1', 'user2'])
-        mockRoom.connectionState = MockConnectionState.CONN_DISCONNECTED
-      })
+    describe('and the room is not connected at routing time', () => {
+      const nonConnectedStates: Array<[string, MockConnectionState]> = [
+        ['disconnected', MockConnectionState.CONN_DISCONNECTED],
+        ['reconnecting', MockConnectionState.CONN_RECONNECTING]
+      ]
 
-      it('should skip publishData and record metrics for failed delivery', async () => {
-        const packet = Packet.create({
-          message: {
-            $case: 'chat',
-            chat: {
-              message: 'Hello world',
-              timestamp: Date.now()
+      it.each(nonConnectedStates)(
+        'should skip database lookups and publishData and record metrics for failed delivery when state is %s',
+        async (_label, state) => {
+          mockRoom.connectionState = state
+          const packet = Packet.create({
+            message: {
+              $case: 'chat',
+              chat: {
+                message: 'Hello world',
+                timestamp: Date.now()
+              }
             }
+          })
+          const message: IncomingMessage = {
+            packet,
+            from: 'test-user',
+            communityId: 'test-community'
           }
-        })
-        const message: IncomingMessage = {
-          packet,
-          from: 'test-user',
-          communityId: 'test-community'
+
+          await messageRouting.routeMessage(mockRoom as any, message)
+
+          expect(mockDB.belongsToCommunity).not.toHaveBeenCalled()
+          expect(mockDB.getCommunityMembers).not.toHaveBeenCalled()
+          expect(mockRoom.localParticipant.publishData).not.toHaveBeenCalled()
+          expect(mockMetrics.increment).toHaveBeenCalledWith('message_delivery_total', { outcome: 'failed' })
+          expect(mockTimer.end).toHaveBeenCalled()
         }
-
-        await messageRouting.routeMessage(mockRoom as any, message)
-
-        expect(mockRoom.localParticipant.publishData).not.toHaveBeenCalled()
-        expect(mockMetrics.increment).toHaveBeenCalledWith('message_delivery_total', { outcome: 'failed' })
-        expect(mockTimer.end).toHaveBeenCalled()
-      })
+      )
     })
 
-    describe('and the room is reconnecting before publish', () => {
+    describe('and the room transitions out of connected after database lookups but before publish', () => {
       beforeEach(() => {
         mockDB.belongsToCommunity.mockResolvedValue(true)
-        mockDB.getCommunityMembers.mockResolvedValue(['user1', 'user2'])
-        mockRoom.connectionState = MockConnectionState.CONN_RECONNECTING
+        // Flip the connection state during the members lookup so the per-batch guard
+        // is exercised — the early check passes but the publish-time check should bail.
+        mockDB.getCommunityMembers.mockImplementation(async () => {
+          mockRoom.connectionState = MockConnectionState.CONN_RECONNECTING
+          return ['user1', 'user2']
+        })
       })
 
       it('should skip publishData and record metrics for failed delivery', async () => {
@@ -357,6 +366,7 @@ describe('when handling message routing', () => {
 
         await messageRouting.routeMessage(mockRoom as any, message)
 
+        expect(mockDB.getCommunityMembers).toHaveBeenCalled()
         expect(mockRoom.localParticipant.publishData).not.toHaveBeenCalled()
         expect(mockMetrics.increment).toHaveBeenCalledWith('message_delivery_total', { outcome: 'failed' })
         expect(mockTimer.end).toHaveBeenCalled()

--- a/test/unit/message-routing.spec.ts
+++ b/test/unit/message-routing.spec.ts
@@ -7,7 +7,7 @@ import {
 } from '../../src/logic/message-routing'
 import { IDatabaseComponent } from '../../src/adapters/db'
 import { createTestLogsComponent } from '../mocks/components'
-import { MockRoom, mockRoom } from '../mocks/livekit'
+import { MockConnectionState, MockRoom, mockRoom } from '../mocks/livekit'
 import { metricDeclarations } from '../../src/metrics'
 import { Chat, ChatReaction, Packet } from '@dcl/protocol/out-js/decentraland/kernel/comms/rfc4/comms.gen'
 
@@ -90,6 +90,10 @@ describe('when handling message routing', () => {
   })
 
   describe('when routing messages', () => {
+    beforeEach(() => {
+      mockRoom.connectionState = MockConnectionState.CONN_CONNECTED
+    })
+
     it('should start a timer to record message delivery latency', async () => {
       const packet = Packet.create({
         message: {
@@ -292,6 +296,68 @@ describe('when handling message routing', () => {
         expect(mockDB.belongsToCommunity).toHaveBeenCalledWith('test-community', 'test-user')
         expect(mockRoom.localParticipant.publishData).not.toHaveBeenCalled()
         expect(mockMetrics.startTimer).toHaveBeenCalledWith('message_delivery_latency')
+        expect(mockMetrics.increment).toHaveBeenCalledWith('message_delivery_total', { outcome: 'failed' })
+        expect(mockTimer.end).toHaveBeenCalled()
+      })
+    })
+
+    describe('and the room becomes disconnected before publish', () => {
+      beforeEach(() => {
+        mockDB.belongsToCommunity.mockResolvedValue(true)
+        mockDB.getCommunityMembers.mockResolvedValue(['user1', 'user2'])
+        mockRoom.connectionState = MockConnectionState.CONN_DISCONNECTED
+      })
+
+      it('should skip publishData and record metrics for failed delivery', async () => {
+        const packet = Packet.create({
+          message: {
+            $case: 'chat',
+            chat: {
+              message: 'Hello world',
+              timestamp: Date.now()
+            }
+          }
+        })
+        const message: IncomingMessage = {
+          packet,
+          from: 'test-user',
+          communityId: 'test-community'
+        }
+
+        await messageRouting.routeMessage(mockRoom as any, message)
+
+        expect(mockRoom.localParticipant.publishData).not.toHaveBeenCalled()
+        expect(mockMetrics.increment).toHaveBeenCalledWith('message_delivery_total', { outcome: 'failed' })
+        expect(mockTimer.end).toHaveBeenCalled()
+      })
+    })
+
+    describe('and the room is reconnecting before publish', () => {
+      beforeEach(() => {
+        mockDB.belongsToCommunity.mockResolvedValue(true)
+        mockDB.getCommunityMembers.mockResolvedValue(['user1', 'user2'])
+        mockRoom.connectionState = MockConnectionState.CONN_RECONNECTING
+      })
+
+      it('should skip publishData and record metrics for failed delivery', async () => {
+        const packet = Packet.create({
+          message: {
+            $case: 'chat',
+            chat: {
+              message: 'Hello world',
+              timestamp: Date.now()
+            }
+          }
+        })
+        const message: IncomingMessage = {
+          packet,
+          from: 'test-user',
+          communityId: 'test-community'
+        }
+
+        await messageRouting.routeMessage(mockRoom as any, message)
+
+        expect(mockRoom.localParticipant.publishData).not.toHaveBeenCalled()
         expect(mockMetrics.increment).toHaveBeenCalledWith('message_delivery_total', { outcome: 'failed' })
         expect(mockTimer.end).toHaveBeenCalled()
       })

--- a/yarn.lock
+++ b/yarn.lock
@@ -285,6 +285,11 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
+"@datastructures-js/deque@1.0.8":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@datastructures-js/deque/-/deque-1.0.8.tgz#7ef2b655821ea24b1677ff01895a8fdb8a26d3c7"
+  integrity sha512-PSBhJ2/SmeRPRHuBv7i/fHWIdSC3JTyq56qb+Rq0wjOagi0/fdV5/B/3Md5zFZus/W6OkSPMaxMKKMNMrSmubg==
+
 "@dcl/eslint-config@^2.4.3":
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/@dcl/eslint-config/-/eslint-config-2.4.3.tgz#505f4817c6a5750e762163c42b68b113c5ea93be"
@@ -302,9 +307,10 @@
     eslint-plugin-prettier "^5.1.3"
     prettier "^3.3.2"
 
-"@dcl/protocol@https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-22997207545.commit-32bf1fb.tgz":
-  version "1.0.0-22997207545.commit-32bf1fb"
-  resolved "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-22997207545.commit-32bf1fb.tgz#a87e26f49b30180bec23ca2010669f2c23c8c8a5"
+"@dcl/protocol@experimental":
+  version "1.0.0-24513643863.commit-4851fd6"
+  resolved "https://registry.yarnpkg.com/@dcl/protocol/-/protocol-1.0.0-24513643863.commit-4851fd6.tgz#740cd0be97d3294a8df2117b8c1a17f72ac7bffe"
+  integrity sha512-AbQ1exc37Uve3N7egafyBnJbIfH7Ppyq6iGMYVZgGnNNuWXhV0RIv3bNV9CMEYWE/E0Ryjq4Ngzst2MWfIVtog==
   dependencies:
     "@dcl/ts-proto" "1.154.0"
     protobufjs "7.2.4"
@@ -655,47 +661,55 @@
   dependencies:
     "@bufbuild/protobuf" "^1.10.0"
 
-"@livekit/rtc-node-darwin-arm64@0.13.14":
-  version "0.13.14"
-  resolved "https://registry.npmjs.org/@livekit/rtc-node-darwin-arm64/-/rtc-node-darwin-arm64-0.13.14.tgz"
-  integrity sha512-o1g2mPvbTROqbs2G0rULJ4uvyN8/H29MA9RCxtxKVshwZhTWHKZ2FIkSZpiOUPnzQfPP8ZISgo8i5vqxq6qjvQ==
+"@livekit/rtc-ffi-bindings-darwin-arm64@0.12.52-patch.0":
+  version "0.12.52-patch.0"
+  resolved "https://registry.yarnpkg.com/@livekit/rtc-ffi-bindings-darwin-arm64/-/rtc-ffi-bindings-darwin-arm64-0.12.52-patch.0.tgz#ef54411e8e6c640cfedc9e6560af878299506245"
+  integrity sha512-IKUir6goV8yVRR7E2qrAP0JtH7gUyMkO0TG8G+dopO/fkXAsPpSealgI9fLcBJl0zhKK+eGCr741r6xR+xxsVw==
 
-"@livekit/rtc-node-darwin-x64@0.13.14":
-  version "0.13.14"
-  resolved "https://registry.yarnpkg.com/@livekit/rtc-node-darwin-x64/-/rtc-node-darwin-x64-0.13.14.tgz#f55f31a68812f5713f2a9aa4cc8c6f57c7ce5eaf"
-  integrity sha512-MBVXapEig6kfXyhhGJ8CwwCs1gj3qU2MkJ7zB2AfO9hKxIwWCecghOqipSu93xVybrmshoRNadSqL3G0A/K67A==
+"@livekit/rtc-ffi-bindings-darwin-x64@0.12.52-patch.0":
+  version "0.12.52-patch.0"
+  resolved "https://registry.yarnpkg.com/@livekit/rtc-ffi-bindings-darwin-x64/-/rtc-ffi-bindings-darwin-x64-0.12.52-patch.0.tgz#4922e9a9f8ea2e84b6ae9703374737c8a04e95dc"
+  integrity sha512-h2oKdGvK4E4nYxHc+hsHkYu+oJIhKKqrC96v1XSGa5fgIEcq4Bve6tNEwUCBTkvuGh/I2tOI83udgcF4P4+mhQ==
 
-"@livekit/rtc-node-linux-arm64-gnu@0.13.14":
-  version "0.13.14"
-  resolved "https://registry.yarnpkg.com/@livekit/rtc-node-linux-arm64-gnu/-/rtc-node-linux-arm64-gnu-0.13.14.tgz#2b032c8ff8b8c322d700a1eac074fae143f934e6"
-  integrity sha512-dKkArPtKqbjdnmhOD+h4PmssVHCW2joZPPlNjIcFLZ8WqC306VNVVr89dg11otBS0XzuGibvDU0hq/ivQgCl2Q==
+"@livekit/rtc-ffi-bindings-linux-arm64-gnu@0.12.52-patch.0":
+  version "0.12.52-patch.0"
+  resolved "https://registry.yarnpkg.com/@livekit/rtc-ffi-bindings-linux-arm64-gnu/-/rtc-ffi-bindings-linux-arm64-gnu-0.12.52-patch.0.tgz#9cbd82cbd98fe401f36cfc3838530cb852818860"
+  integrity sha512-bWtJ3r+wQ1Fd8s8jiM7GnBMfaKepSYk5c4bgimMIC4mkz+puChpfaj9avz1M271FUgxnIAKCTz6fPN2ygIAFnw==
 
-"@livekit/rtc-node-linux-x64-gnu@0.13.14":
-  version "0.13.14"
-  resolved "https://registry.yarnpkg.com/@livekit/rtc-node-linux-x64-gnu/-/rtc-node-linux-x64-gnu-0.13.14.tgz#5a3510079c0648d7dc4b1ffe7f1c01ebb2df2be3"
-  integrity sha512-z8g2aH+pmK90sC1L+MmGghk4mSIqQZ+mnarZhw0r3NBOWa30kOH7uzGm/ehck64ATQc/8k5aouwESbkyR5M08Q==
+"@livekit/rtc-ffi-bindings-linux-x64-gnu@0.12.52-patch.0":
+  version "0.12.52-patch.0"
+  resolved "https://registry.yarnpkg.com/@livekit/rtc-ffi-bindings-linux-x64-gnu/-/rtc-ffi-bindings-linux-x64-gnu-0.12.52-patch.0.tgz#01074c7f358415764126acfe3442174009f83abb"
+  integrity sha512-y1j4ciiCMaUrii0/XYwLFyRBRHDvx4202YCK5ePF3xB+9tW3Fuwexd/z4GuupCpP9eadGkpALCQt60wnLnFDnw==
 
-"@livekit/rtc-node-win32-x64-msvc@0.13.14":
-  version "0.13.14"
-  resolved "https://registry.yarnpkg.com/@livekit/rtc-node-win32-x64-msvc/-/rtc-node-win32-x64-msvc-0.13.14.tgz#f230334e277ab9d6daea3426c72b485f77e9479d"
-  integrity sha512-DTwNhwq6xoesT6zr19F7fnOkzBxHtLXYyhnRzK6JzieWWxclKGNaUKaBeUPvvQjOwttwYUbf6djqO78ylvDA4Q==
+"@livekit/rtc-ffi-bindings-win32-x64-msvc@0.12.52-patch.0":
+  version "0.12.52-patch.0"
+  resolved "https://registry.yarnpkg.com/@livekit/rtc-ffi-bindings-win32-x64-msvc/-/rtc-ffi-bindings-win32-x64-msvc-0.12.52-patch.0.tgz#36ae23f1807dd6d965ca38305f364e4deacb53c3"
+  integrity sha512-a7eoTor7KgN4JDPqZjyBQjgkVIZcxkyP5Iau3O/1qDaYKboLMqSYHfSAk84Un4r0SsSFvxUXXDY3boMLJ7QYow==
 
-"@livekit/rtc-node@^0.13.14":
-  version "0.13.14"
-  resolved "https://registry.npmjs.org/@livekit/rtc-node/-/rtc-node-0.13.14.tgz"
-  integrity sha512-PU3mYvnY6bZwpc483Yt5aLy1Xi0GM4fj5kuv6tfvLE8w1/kOrCQ8jrHxRY/GWT9SqbB8kf8eIkA/aDtyTx+DZQ==
+"@livekit/rtc-ffi-bindings@0.12.52-patch.0":
+  version "0.12.52-patch.0"
+  resolved "https://registry.yarnpkg.com/@livekit/rtc-ffi-bindings/-/rtc-ffi-bindings-0.12.52-patch.0.tgz#f79c006a7cafa0fb0b5ac0555d701d00dbe44001"
+  integrity sha512-e01PH3AAS0/oN93LzgLDycDWzLGCpHqvZ35qzSuBWrG7V9mmQpdW/bOc6r9UFGZx/BcUXov4OTtao4OyDVVyHw==
   dependencies:
-    "@bufbuild/protobuf" "^1.10.0"
+    "@bufbuild/protobuf" "^1.10.1"
+  optionalDependencies:
+    "@livekit/rtc-ffi-bindings-darwin-arm64" "0.12.52-patch.0"
+    "@livekit/rtc-ffi-bindings-darwin-x64" "0.12.52-patch.0"
+    "@livekit/rtc-ffi-bindings-linux-arm64-gnu" "0.12.52-patch.0"
+    "@livekit/rtc-ffi-bindings-linux-x64-gnu" "0.12.52-patch.0"
+    "@livekit/rtc-ffi-bindings-win32-x64-msvc" "0.12.52-patch.0"
+
+"@livekit/rtc-node@^0.13.27":
+  version "0.13.27"
+  resolved "https://registry.yarnpkg.com/@livekit/rtc-node/-/rtc-node-0.13.27.tgz#3787d1d88697777741ee1284aec71ee192ab6142"
+  integrity sha512-IuP8lG57ceqJ7HyPS6GX7Moaj6jK/OZnm3/QM+NG8fpnoOUOsh4Q+aQ0kWYONgasW1SvUTtMStOkwhM6Au2i9w==
+  dependencies:
+    "@datastructures-js/deque" "1.0.8"
     "@livekit/mutex" "^1.0.0"
+    "@livekit/rtc-ffi-bindings" "0.12.52-patch.0"
     "@livekit/typed-emitter" "^3.0.0"
     pino "^9.0.0"
     pino-pretty "^13.0.0"
-  optionalDependencies:
-    "@livekit/rtc-node-darwin-arm64" "0.13.14"
-    "@livekit/rtc-node-darwin-x64" "0.13.14"
-    "@livekit/rtc-node-linux-arm64-gnu" "0.13.14"
-    "@livekit/rtc-node-linux-x64-gnu" "0.13.14"
-    "@livekit/rtc-node-win32-x64-msvc" "0.13.14"
 
 "@livekit/typed-emitter@^3.0.0":
   version "3.0.0"


### PR DESCRIPTION
## Summary

- Add a `ConnectionState` check in `routeMessage` immediately before each `publishData`. A concurrent reconnect can tear down a `Room`'s native state while a routing call is still in flight (long DB lookups, batched publishes); calling `publishData` on a torn-down `Room` is a known SIGSEGV path inside `@livekit/rtc-node`. The guard short-circuits via the existing failed-delivery metric.
- Bump `@livekit/rtc-node` `^0.13.14` → `^0.13.27`. Intervening releases include several fixes targeting this crash class: FFI event ordering (#508, #547), "wait for disconnect response on disconnect" (#562), native handle disposal on disconnect (#633/#634/#637/#639/#652), and connection-state consistency (#653/#655).
- Switch `@dcl/protocol` to the `experimental` dist-tag (`1.0.0-24513643863.commit-4851fd6`). The previous CDN tarball pin pointed at an experimental-branch build; switching to the dist-tag keeps that and makes future bumps tractable. `Chat.forwarded_from` (used by `routeMessage` to stamp the original sender on outbound chat) only lives on `experimental` — `main` doesn't have the field.

Context: ECS task `comms-message-sfu-blue-c1f1829` (DEV) crashed with exit 139 after `RoomEvent.Reconnecting`, with a 6-minute silent gap before SIGSEGV — i.e. the death happened inside the SDK's native reconnect loop. The bump targets the SDK-side crash; the guard closes a separate, latent app-side path that could produce the same signature.

## Test plan

- [x] `yarn build`
- [x] `yarn test test/unit` — 68 tests, 10 suites, all green. New cases cover `CONN_DISCONNECTED` and `CONN_RECONNECTING` states (publishData not invoked, failed metric incremented).
- [ ] Deploy to dev and watch CloudWatch for SIGSEGV recurrence on the next forced reconnect.