### PR TITLE
fix: parameterize community members query to prevent sql injection

### DIFF
--- a/src/adapters/db.ts
+++ b/src/adapters/db.ts
@@ -29,20 +29,20 @@ export async function createDBComponent(components: Pick<AppComponents, 'pg'>): 
       exclude?: string[]
     }
   ) => {
-    const includeAddresses = options?.include?.map((address) => `'${address.toLowerCase()}'`)
-    const excludeAddresses = options?.exclude?.map((address) => `'${address.toLowerCase()}'`)
+    const includeAddresses = options?.include?.map((address) => address.toLowerCase())
+    const excludeAddresses = options?.exclude?.map((address) => address.toLowerCase())
 
     const query = SQL`
       SELECT LOWER(cm.member_address) as address FROM communities c
       LEFT JOIN community_members cm ON cm.community_id = c.id
       WHERE c.id = ${communityId} AND c.active = TRUE`
 
-    if (includeAddresses) {
-      query.append(` AND cm.member_address IN (${includeAddresses.join(',')})`)
+    if (includeAddresses && includeAddresses.length > 0) {
+      query.append(SQL` AND cm.member_address = ANY(${includeAddresses})`)
     }
 
-    if (excludeAddresses) {
-      query.append(` AND cm.member_address NOT IN (${excludeAddresses.join(',')})`)
+    if (excludeAddresses && excludeAddresses.length > 0) {
+      query.append(SQL` AND cm.member_address <> ALL(${excludeAddresses})`)
     }
 
     const result = await pg.query(query)

--- a/test/unit/db.spec.ts
+++ b/test/unit/db.spec.ts
@@ -40,8 +40,8 @@ describe('when handling database component', () => {
 
       expect(mockPg.query).toHaveBeenCalledWith(
         expect.objectContaining({
-          text: expect.stringContaining("AND cm.member_address IN ('0x123','0x456')"),
-          values: [communityId]
+          text: expect.stringContaining('AND cm.member_address = ANY('),
+          values: [communityId, ['0x123', '0x456']]
         })
       )
       expect(members).toEqual(['0x123', '0x456'])
@@ -58,8 +58,8 @@ describe('when handling database component', () => {
 
       expect(mockPg.query).toHaveBeenCalledWith(
         expect.objectContaining({
-          text: expect.stringContaining("AND cm.member_address NOT IN ('0x789')"),
-          values: [communityId]
+          text: expect.stringContaining('AND cm.member_address <> ALL('),
+          values: [communityId, ['0x789']]
         })
       )
       expect(members).toEqual(['0x123', '0x456'])
@@ -76,9 +76,9 @@ describe('when handling database component', () => {
       const members = await db.getCommunityMembers(communityId, { include, exclude })
 
       const queryCall = mockPg.query.mock.calls[0][0]
-      expect(queryCall.text).toContain("AND cm.member_address IN ('0x123','0x456')")
-      expect(queryCall.text).toContain("AND cm.member_address NOT IN ('0x789')")
-      expect(queryCall.values).toEqual([communityId])
+      expect(queryCall.text).toContain('AND cm.member_address = ANY(')
+      expect(queryCall.text).toContain('AND cm.member_address <> ALL(')
+      expect(queryCall.values).toEqual([communityId, include, exclude])
       expect(members).toEqual(['0x123', '0x456'])
     })
 


### PR DESCRIPTION
## What

`getCommunityMembers` built its `include`/`exclude` filters by manually wrapping each address in single quotes and concatenating them into the query via `query.append(\`... IN (${addresses.join(',')})\`)`, which embeds them as literal SQL instead of bound parameters. A value containing a single quote breaks out of the literal.

The reachable input today (`exclude: [from]`) comes from the LiveKit token identity, which comms-gatekeeper restricts to validated lowercase wallet addresses, so it is not exploitable from outside right now — but the pattern is unsafe and breaks defense in depth.

## Change

Pass the address arrays as bound parameters using `= ANY(${...})` / `<> ALL(${...})`. `communityId` was already parameterized. Empty arrays are now guarded explicitly.

## Verification

- `tsc --noEmit` clean
- eslint clean on changed file