### PR TITLE
fix: cap incoming packet size and rate limit routed messages

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -25,3 +25,15 @@ LIVEKIT_API_SECRET=your-livekit-api-secret
 LIVEKIT_ROOM_ID=your-room-id
 LIVEKIT_IDENTITY_PREFIX=message-router
 REPLICA_ID=0
+
+# Maximum size (in bytes) of an incoming data packet. Larger packets are dropped before
+# being decoded to prevent resource-exhaustion via oversized payloads.
+MAX_PACKET_SIZE_BYTES=8192
+
+# Per-participant token-bucket rate limiting for routed messages.
+# RATE_LIMIT_MAX_TOKENS is the burst allowance; RATE_LIMIT_REFILL_RATE_PER_SECOND is the
+# sustained messages-per-second rate. Idle buckets are pruned every
+# RATE_LIMIT_CLEANUP_INTERVAL_MS to keep memory bounded.
+RATE_LIMIT_MAX_TOKENS=10
+RATE_LIMIT_REFILL_RATE_PER_SECOND=5
+RATE_LIMIT_CLEANUP_INTERVAL_MS=60000

--- a/src/adapters/rate-limiter.ts
+++ b/src/adapters/rate-limiter.ts
@@ -1,0 +1,97 @@
+import { IBaseComponent, START_COMPONENT, STOP_COMPONENT } from '@well-known-components/interfaces'
+import { AppComponents } from '../types'
+
+export type IRateLimiterComponent = IBaseComponent & {
+  /**
+   * Attempts to consume a single token for the given key (e.g. a participant identity).
+   *
+   * @param key - The bucket key to rate limit on (a participant identity).
+   * @returns `true` when the call is within the configured rate limit and a token was
+   * consumed, or `false` when the caller has exhausted their allowance and should be throttled.
+   */
+  isAllowed: (key: string) => boolean
+}
+
+type TokenBucket = {
+  tokens: number
+  lastRefill: number
+}
+
+/**
+ * Creates an in-memory, per-key token-bucket rate limiter.
+ *
+ * Each key (a participant identity) gets a bucket that starts full and refills continuously
+ * at `RATE_LIMIT_REFILL_RATE_PER_SECOND` up to a ceiling of `RATE_LIMIT_MAX_TOKENS`, which
+ * also acts as the burst allowance. A periodic sweep drops buckets that have been idle long
+ * enough to be fully refilled — an idle full bucket is indistinguishable from a fresh one, so
+ * dropping it keeps memory bounded without changing behaviour.
+ *
+ * @param components - The config and logs components.
+ * @returns A rate limiter component exposing `isAllowed` plus start/stop lifecycle hooks.
+ */
+export async function createRateLimiterComponent(
+  components: Pick<AppComponents, 'config' | 'logs'>
+): Promise<IRateLimiterComponent> {
+  const { config, logs } = components
+  const logger = logs.getLogger('rate-limiter')
+
+  const maxTokens = (await config.getNumber('RATE_LIMIT_MAX_TOKENS')) ?? 10
+  const refillRatePerSecond = (await config.getNumber('RATE_LIMIT_REFILL_RATE_PER_SECOND')) ?? 5
+  const cleanupIntervalMs = (await config.getNumber('RATE_LIMIT_CLEANUP_INTERVAL_MS')) ?? 60_000
+
+  // Time it takes for an empty bucket to refill completely. A bucket untouched for at least
+  // this long is equivalent to a fresh one, so it can be dropped to keep memory bounded.
+  const fullRefillMs = (maxTokens / refillRatePerSecond) * 1000
+
+  const buckets = new Map<string, TokenBucket>()
+  let cleanupTimer: ReturnType<typeof setInterval> | null = null
+
+  function isAllowed(key: string): boolean {
+    const now = Date.now()
+    let bucket = buckets.get(key)
+
+    if (!bucket) {
+      bucket = { tokens: maxTokens, lastRefill: now }
+      buckets.set(key, bucket)
+    } else {
+      const elapsedMs = now - bucket.lastRefill
+      if (elapsedMs > 0) {
+        bucket.tokens = Math.min(maxTokens, bucket.tokens + (elapsedMs / 1000) * refillRatePerSecond)
+        bucket.lastRefill = now
+      }
+    }
+
+    if (bucket.tokens >= 1) {
+      bucket.tokens -= 1
+      return true
+    }
+
+    return false
+  }
+
+  function cleanup() {
+    const now = Date.now()
+    for (const [key, bucket] of buckets) {
+      if (now - bucket.lastRefill >= fullRefillMs) {
+        buckets.delete(key)
+      }
+    }
+  }
+
+  return {
+    isAllowed,
+    [START_COMPONENT]: async () => {
+      logger.debug('Starting rate limiter', { maxTokens, refillRatePerSecond, cleanupIntervalMs })
+      cleanupTimer = setInterval(cleanup, cleanupIntervalMs)
+      // Don't keep the event loop alive solely for the cleanup timer.
+      cleanupTimer.unref?.()
+    },
+    [STOP_COMPONENT]: async () => {
+      if (cleanupTimer) {
+        clearInterval(cleanupTimer)
+        cleanupTimer = null
+      }
+      buckets.clear()
+    }
+  }
+}

--- a/src/components.ts
+++ b/src/components.ts
@@ -11,6 +11,7 @@ import { metricDeclarations } from './metrics'
 import { createPgComponent } from '@well-known-components/pg-component'
 import { createDBComponent } from './adapters/db'
 import { createLivekitComponent } from './adapters/livekit'
+import { createRateLimiterComponent } from './adapters/rate-limiter'
 import { createMessageRouting } from './logic/message-routing'
 import { createDataReceivedHandler } from './logic/data-received-handler'
 import { createConnectedHandler } from './logic/connection-handlers/connected'
@@ -40,8 +41,9 @@ export async function initComponents(): Promise<AppComponents> {
   const pg = await createPgComponent({ logs, config, metrics })
   const db = await createDBComponent({ pg })
 
+  const rateLimiter = await createRateLimiterComponent({ config, logs })
   const messageRouting = await createMessageRouting({ db, logs, metrics })
-  const dataReceivedHandler = await createDataReceivedHandler({ logs, messageRouting, metrics })
+  const dataReceivedHandler = await createDataReceivedHandler({ config, logs, messageRouting, metrics, rateLimiter })
   const connectedHandler = await createConnectedHandler({ logs, metrics })
   const reconnectingHandler = await createReconnectingHandler({ logs, metrics })
   const reconnectedHandler = await createReconnectedHandler({ logs, metrics })
@@ -66,6 +68,7 @@ export async function initComponents(): Promise<AppComponents> {
     pg,
     db,
     livekit,
+    rateLimiter,
     messageRouting,
     dataReceivedHandler,
     connectedHandler,

--- a/src/logic/data-received-handler.ts
+++ b/src/logic/data-received-handler.ts
@@ -15,10 +15,14 @@ export type IDataReceivedHandler = {
 }
 
 export async function createDataReceivedHandler(
-  components: Pick<AppComponents, 'logs' | 'messageRouting' | 'metrics'>
+  components: Pick<AppComponents, 'config' | 'logs' | 'messageRouting' | 'metrics' | 'rateLimiter'>
 ): Promise<IDataReceivedHandler> {
-  const { logs, messageRouting, metrics } = components
+  const { config, logs, messageRouting, metrics, rateLimiter } = components
   const logger = logs.getLogger('data-received-handler')
+
+  // Cap incoming payloads before decoding so a participant cannot amplify load with oversized
+  // packets. Chat/chatReaction packets are tiny, so the default leaves ample headroom.
+  const maxPacketSizeInBytes = (await config.getNumber('MAX_PACKET_SIZE_BYTES')) ?? 8192
 
   function handle(room: Room, identity: string) {
     return async (
@@ -44,6 +48,22 @@ export async function createDataReceivedHandler(
 
       if (!topic) {
         logger.error('No community id provided in the topic')
+        return
+      }
+
+      if (payload.byteLength > maxPacketSizeInBytes) {
+        logger.warn('Dropping oversized data packet', {
+          from: participant.identity,
+          sizeInBytes: payload.byteLength,
+          maxPacketSizeInBytes
+        })
+        metrics.increment('message_delivery_total', { outcome: 'rejected_oversized' })
+        return
+      }
+
+      if (!rateLimiter.isAllowed(participant.identity)) {
+        logger.warn('Rate limit exceeded, dropping data packet', { from: participant.identity })
+        metrics.increment('message_delivery_total', { outcome: 'rate_limited' })
         return
       }
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -14,7 +14,7 @@ export const metricDeclarations = {
   message_delivery_total: {
     type: IMetricsComponent.CounterType,
     help: 'Total number of messages processed',
-    labelNames: ['outcome'] // delivered, failed
+    labelNames: ['outcome'] // delivered, failed, rejected_oversized, rate_limited
   },
   livekit_connection_status: {
     type: IMetricsComponent.GaugeType,

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ import { metricDeclarations } from './metrics'
 import { IPgComponent } from '@well-known-components/pg-component'
 import { IDatabaseComponent } from './adapters/db'
 import { ILivekitComponent } from './adapters/livekit'
+import { IRateLimiterComponent } from './adapters/rate-limiter'
 import { IMessageRoutingComponent } from './logic/message-routing'
 import { IDataReceivedHandler } from './logic/data-received-handler'
 import { IReconnectedHandler } from './logic/connection-handlers/reconnected'
@@ -35,6 +36,7 @@ export type AppComponents = BaseComponents & {
   pg: IPgComponent
   db: IDatabaseComponent
   livekit: ILivekitComponent
+  rateLimiter: IRateLimiterComponent
   messageRouting: IMessageRoutingComponent
   dataReceivedHandler: IDataReceivedHandler
   connectedHandler: IConnectedHandler

--- a/test/mocks/components.ts
+++ b/test/mocks/components.ts
@@ -1,6 +1,7 @@
-import { ILoggerComponent } from '@well-known-components/interfaces'
+import { IConfigComponent, ILoggerComponent } from '@well-known-components/interfaces'
 import { IPgComponent } from '@well-known-components/pg-component'
 import { IDatabaseComponent } from '../../src/adapters/db'
+import { IRateLimiterComponent } from '../../src/adapters/rate-limiter'
 import { IMessageRoutingComponent } from '../../src/logic/message-routing'
 
 export function createTestDBComponent(): jest.Mocked<IDatabaseComponent> {
@@ -25,6 +26,27 @@ export function createTestLogsComponent(): jest.Mocked<ILoggerComponent> {
 export function createTestMessageRoutingComponent(): jest.Mocked<IMessageRoutingComponent> {
   return {
     routeMessage: jest.fn()
+  }
+}
+
+export function createTestRateLimiterComponent(): jest.Mocked<IRateLimiterComponent> {
+  return {
+    isAllowed: jest.fn().mockReturnValue(true)
+  } as jest.Mocked<IRateLimiterComponent>
+}
+
+export function createTestConfigComponent(values: Record<string, string | number> = {}): jest.Mocked<IConfigComponent> {
+  return {
+    getString: jest.fn(async (name: string) => {
+      const value = values[name]
+      return value === undefined ? undefined : String(value)
+    }),
+    getNumber: jest.fn(async (name: string) => {
+      const value = values[name]
+      return value === undefined ? undefined : Number(value)
+    }),
+    requireString: jest.fn(async (name: string) => String(values[name])),
+    requireNumber: jest.fn(async (name: string) => Number(values[name]))
   }
 }
 

--- a/test/unit/data-received-handler.spec.ts
+++ b/test/unit/data-received-handler.spec.ts
@@ -1,19 +1,27 @@
 // test/unit/data-received-handler.spec.ts
 
 import { createDataReceivedHandler, IDataReceivedHandler } from '../../src/logic/data-received-handler'
-import { createTestLogsComponent, createTestMessageRoutingComponent } from '../mocks/components'
+import {
+  createTestConfigComponent,
+  createTestLogsComponent,
+  createTestMessageRoutingComponent,
+  createTestRateLimiterComponent
+} from '../mocks/components'
 import { mockRoom } from '../mocks/livekit'
 import { IMessageRoutingComponent } from '../../src/logic/message-routing'
+import { IRateLimiterComponent } from '../../src/adapters/rate-limiter'
 import { createTestMetricsComponent } from '@well-known-components/metrics'
 import { metricDeclarations } from '../../src/metrics'
 import { Packet } from '@dcl/protocol/out-js/decentraland/kernel/comms/rfc4/comms.gen'
-import { ILoggerComponent, IMetricsComponent } from '@well-known-components/interfaces'
+import { IConfigComponent, ILoggerComponent, IMetricsComponent } from '@well-known-components/interfaces'
 
 describe('when handling data received', () => {
   let dataReceivedHandler: IDataReceivedHandler
   let mockMessageRouting: jest.Mocked<IMessageRoutingComponent>
   let mockLogs: jest.Mocked<ILoggerComponent>
   let mockMetrics: IMetricsComponent<keyof typeof metricDeclarations>
+  let mockRateLimiter: jest.Mocked<IRateLimiterComponent>
+  let mockConfig: jest.Mocked<IConfigComponent>
 
   let handleMessage: (payload: Uint8Array, participant?: any, kind?: number, topic?: string) => Promise<void>
 
@@ -21,6 +29,7 @@ describe('when handling data received', () => {
   const participant = { identity: 'test-user' }
   const kind = 1 // KIND_LOSSY
   const topic = 'community:test-community'
+  const maxPacketSizeInBytes = 8192
 
   let payload: Packet
   let encodedPayload: Uint8Array
@@ -29,10 +38,14 @@ describe('when handling data received', () => {
     mockMessageRouting = createTestMessageRoutingComponent()
     mockLogs = createTestLogsComponent()
     mockMetrics = createTestMetricsComponent(metricDeclarations)
+    mockRateLimiter = createTestRateLimiterComponent()
+    mockConfig = createTestConfigComponent({ MAX_PACKET_SIZE_BYTES: maxPacketSizeInBytes })
     dataReceivedHandler = await createDataReceivedHandler({
+      config: mockConfig,
       logs: mockLogs,
       messageRouting: mockMessageRouting,
-      metrics: mockMetrics
+      metrics: mockMetrics,
+      rateLimiter: mockRateLimiter
     })
 
     handleMessage = dataReceivedHandler.handle(mockRoom as any, identity)
@@ -64,6 +77,56 @@ describe('when handling data received', () => {
           communityId: 'test-community'
         })
       )
+    })
+
+    it('should check the per-participant rate limit using the sender identity', async () => {
+      await handleMessage(encodedPayload, participant, kind, topic)
+
+      expect(mockRateLimiter.isAllowed).toHaveBeenCalledWith('test-user')
+    })
+  })
+
+  describe('and the payload exceeds the maximum allowed size', () => {
+    let oversizedPayload: Uint8Array
+
+    beforeEach(() => {
+      oversizedPayload = new Uint8Array(maxPacketSizeInBytes + 1)
+    })
+
+    it('should not route the message', async () => {
+      await handleMessage(oversizedPayload, participant, kind, topic)
+
+      expect(mockMessageRouting.routeMessage).not.toHaveBeenCalled()
+    })
+
+    it('should not consume a rate limit token', async () => {
+      await handleMessage(oversizedPayload, participant, kind, topic)
+
+      expect(mockRateLimiter.isAllowed).not.toHaveBeenCalled()
+    })
+
+    it('should record metrics for a rejected oversized delivery', async () => {
+      await handleMessage(oversizedPayload, participant, kind, topic)
+
+      expect(mockMetrics.increment).toHaveBeenCalledWith('message_delivery_total', { outcome: 'rejected_oversized' })
+    })
+  })
+
+  describe('and the participant has exceeded their rate limit', () => {
+    beforeEach(() => {
+      mockRateLimiter.isAllowed.mockReturnValue(false)
+    })
+
+    it('should not route the message', async () => {
+      await handleMessage(encodedPayload, participant, kind, topic)
+
+      expect(mockMessageRouting.routeMessage).not.toHaveBeenCalled()
+    })
+
+    it('should record metrics for a rate limited delivery', async () => {
+      await handleMessage(encodedPayload, participant, kind, topic)
+
+      expect(mockMetrics.increment).toHaveBeenCalledWith('message_delivery_total', { outcome: 'rate_limited' })
     })
   })
 

--- a/test/unit/rate-limiter.spec.ts
+++ b/test/unit/rate-limiter.spec.ts
@@ -1,0 +1,125 @@
+import { IConfigComponent, ILoggerComponent, START_COMPONENT, STOP_COMPONENT } from '@well-known-components/interfaces'
+import { createRateLimiterComponent, IRateLimiterComponent } from '../../src/adapters/rate-limiter'
+import { createTestConfigComponent, createTestLogsComponent } from '../mocks/components'
+
+describe('when rate limiting calls per key', () => {
+  let rateLimiter: IRateLimiterComponent
+  let mockConfig: jest.Mocked<IConfigComponent>
+  let mockLogs: jest.Mocked<ILoggerComponent>
+
+  const key = 'test-user'
+  const maxTokens = 3
+  const refillRatePerSecond = 1
+  const cleanupIntervalMs = 1000
+
+  beforeEach(async () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(0)
+
+    mockConfig = createTestConfigComponent({
+      RATE_LIMIT_MAX_TOKENS: maxTokens,
+      RATE_LIMIT_REFILL_RATE_PER_SECOND: refillRatePerSecond,
+      RATE_LIMIT_CLEANUP_INTERVAL_MS: cleanupIntervalMs
+    })
+    mockLogs = createTestLogsComponent()
+
+    rateLimiter = await createRateLimiterComponent({ config: mockConfig, logs: mockLogs })
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  describe('when checking if a call is allowed', () => {
+    describe('and the key has its full burst allowance available', () => {
+      it('should allow up to the configured burst of calls', () => {
+        const results = Array.from({ length: maxTokens }, () => rateLimiter.isAllowed(key))
+
+        expect(results).toEqual([true, true, true])
+      })
+    })
+
+    describe('and the burst allowance has been exhausted', () => {
+      beforeEach(() => {
+        for (let i = 0; i < maxTokens; i++) {
+          rateLimiter.isAllowed(key)
+        }
+      })
+
+      it('should reject the next call', () => {
+        expect(rateLimiter.isAllowed(key)).toBe(false)
+      })
+    })
+
+    describe('and tokens have refilled after enough time has passed', () => {
+      beforeEach(() => {
+        for (let i = 0; i < maxTokens; i++) {
+          rateLimiter.isAllowed(key)
+        }
+        // One full second refills exactly one token at 1 token/second.
+        jest.advanceTimersByTime(1000)
+      })
+
+      it('should allow a call again', () => {
+        expect(rateLimiter.isAllowed(key)).toBe(true)
+      })
+    })
+
+    describe('and different keys are used', () => {
+      beforeEach(() => {
+        for (let i = 0; i < maxTokens; i++) {
+          rateLimiter.isAllowed(key)
+        }
+      })
+
+      it('should track each key independently', () => {
+        expect(rateLimiter.isAllowed('another-user')).toBe(true)
+      })
+    })
+  })
+
+  describe('when the component is started', () => {
+    afterEach(async () => {
+      await rateLimiter[STOP_COMPONENT]!()
+    })
+
+    it('should schedule a periodic cleanup timer', async () => {
+      await rateLimiter[START_COMPONENT]!({} as any)
+
+      expect(jest.getTimerCount()).toBe(1)
+    })
+
+    it('should keep rate limiting functional after the periodic cleanup prunes idle buckets', async () => {
+      await rateLimiter[START_COMPONENT]!({} as any)
+      for (let i = 0; i < maxTokens; i++) {
+        rateLimiter.isAllowed(key)
+      }
+
+      // Run the cleanup interval past the full-refill window so the now-idle bucket is pruned.
+      jest.advanceTimersByTime((maxTokens / refillRatePerSecond) * 1000)
+
+      expect(rateLimiter.isAllowed(key)).toBe(true)
+    })
+  })
+
+  describe('when the component is stopped', () => {
+    beforeEach(async () => {
+      await rateLimiter[START_COMPONENT]!({} as any)
+      for (let i = 0; i < maxTokens; i++) {
+        rateLimiter.isAllowed(key)
+      }
+    })
+
+    it('should clear the cleanup timer', async () => {
+      await rateLimiter[STOP_COMPONENT]!()
+
+      expect(jest.getTimerCount()).toBe(0)
+    })
+
+    it('should clear stored buckets so a previously throttled key is allowed again', async () => {
+      await rateLimiter[STOP_COMPONENT]!()
+
+      expect(rateLimiter.isAllowed(key)).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #128 — incoming LiveKit data packets were decoded and routed with **no payload-size check** and **no rate limiting**. A participant could amplify load (protobuf decode + `db.belongsToCommunity` + `db.getCommunityMembers` + batched fan-out) by sending many or large packets. Sender identity comes from the LiveKit token, so this is purely resource exhaustion, not spoofing.

## Changes

- **New rate-limiter adapter** (`src/adapters/rate-limiter.ts`): per-participant token bucket (`isAllowed(key)`). Each key starts with a full burst allowance (`RATE_LIMIT_MAX_TOKENS`) and refills continuously at `RATE_LIMIT_REFILL_RATE_PER_SECOND`. Stateful component with `START_COMPONENT`/`STOP_COMPONENT`; a periodic `unref`'d sweep prunes idle (fully-refilled) buckets so memory stays bounded.
- **Hardened `data-received-handler`** — the earliest choke point, before any decode or DB work:
  - Drops packets where `payload.byteLength > MAX_PACKET_SIZE_BYTES` (default 8 KiB) **before** `Packet.decode`.
  - Drops packets when the sender is over their rate limit.
- **Observability**: dropped packets recorded as `message_delivery_total{outcome=rejected_oversized}` / `{outcome=rate_limited}`.
- **Config**: documented `MAX_PACKET_SIZE_BYTES`, `RATE_LIMIT_MAX_TOKENS`, `RATE_LIMIT_REFILL_RATE_PER_SECOND`, `RATE_LIMIT_CLEANUP_INTERVAL_MS` in `.env.default` (sane defaults: 8 KiB, burst 10, 5 msg/s sustained).

## Tests

- New `test/unit/rate-limiter.spec.ts`: burst allowance, exhaustion, time-based refill, per-key isolation, lifecycle cleanup.
- Extended `data-received-handler.spec.ts`: oversized drop, rate-limited drop, and that an oversized packet doesn't consume a token.
- `yarn test test/unit` → 83 passing; `yarn build` (tsc) and `yarn lint:check` clean.

> Note: `test/integration/app.spec.ts` requires a live Postgres (boots the real `pg` component) and fails locally without docker-compose up — this is pre-existing/environmental and unrelated to these changes.

## Notes

- Follows this repo's single-file-component convention rather than the multi-file WKC layout (per `CLAUDE.md`).
- Chose a token bucket (burst + sustained rate) over a fixed window since chat traffic is bursty. Defaults are conservative — happy to tune.

🤖 Generated with [Claude Code](https://claude.com/claude-code)