### PR TITLE
chore: pin node 24 base image to sha256 digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Not support for Alpine based image: https://github.com/livekit/node-sdks/issues/316
-FROM node:24-slim AS builderenv
+FROM node:24-slim@sha256:c2d5ade763cacfb03fe9cb8e8af5d1be5041ff331921fa26a9b231ca3a4f780a AS builderenv
 
 WORKDIR /app
 
@@ -24,7 +24,7 @@ RUN yarn install --prod --frozen-lockfile
 
 ########################## END OF BUILD STAGE ##########################
 
-FROM node:24-slim
+FROM node:24-slim@sha256:c2d5ade763cacfb03fe9cb8e8af5d1be5041ff331921fa26a9b231ca3a4f780a
 
 # Install only the essential runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Sets the base image to `node:24-slim@sha256:c2d5ade763cacfb03fe9cb8e8af5d1be5041ff331921fa26a9b231ca3a4f780a` (was `node:24-slim`) and pins it to an immutable sha256 digest for reproducible builds.