### PR TITLE
fix: cancel undrained response bodies and bump @dcl core-components/core-libs deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@dcl/core-commons": "^0.10.1",
     "@dcl/eslint-config": "^2.4.3",
-    "@dcl/http-server": "^2.0.2",
+    "@dcl/http-server": "^2.1.0",
     "@dcl/metrics": "^1.0.1",
     "@dcl/pg-component": "^0.2.0",
     "@dcl/protocol": "experimental",

--- a/yarn.lock
+++ b/yarn.lock
@@ -331,10 +331,10 @@
     eslint-plugin-prettier "^5.1.3"
     prettier "^3.3.2"
 
-"@dcl/http-server@^2.0.2":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@dcl/http-server/-/http-server-2.0.3.tgz#0897b14327ef1d5ffcc2c77d3f012c4113650f4d"
-  integrity sha512-viIRBUk0Gnh39CgpOUXHjXfK85PYejvkScTlHAwAyUFHir01Qh3FMztZUOcO9uEEdbMXdJf7HuJfSDbXJv1gNw==
+"@dcl/http-server@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@dcl/http-server/-/http-server-2.1.0.tgz#5385ba3319356d32d468365a84530f24e245fa65"
+  integrity sha512-UqIFIo18JeKklM/RM0wEJ0u/DCGjikBHtQ1LzuQKjDK6SP9XgeVhukgCg5BmdW0D3Qzlql2i5CGpW4EdyfUiWQ==
   dependencies:
     "@dcl/core-commons" "0.10.1"
     "@well-known-components/interfaces" "^1.5.1"


### PR DESCRIPTION
## Summary

Combined PR to (a) cancel any undrained undici response bodies and (b) bump `@dcl` core-components/core-libs dependencies to their latest published versions, on the default branch (`main`).

## Response-body leak fixes

None. I audited the entire `src` tree for sites that obtain an HTTP `Response` (`fetch.fetch(...)`, native `fetch(...)`, `node-fetch`, an injected `IFetchComponent.fetch(...)`, and any LRU-cache `fetchMethod` that performs an HTTP fetch). There are **no HTTP fetch call sites** in the source:

- `IFetchComponent` only appears as the `localFetch` type in `src/types.ts`; it is created solely in `test/components.ts` via `createLocalFetchComponent` (a test harness over the local server) and is never invoked in production code.
- The LiveKit adapter (`src/adapters/livekit.ts`) connects via the WebSocket-based `@livekit/rtc-node` / `livekit-server-sdk` (`room.connect`), not undici fetch, so there is no response body to drain.
- No `.json()` / `.text()` / `.arrayBuffer()` / `.body` reads or discards exist anywhere.

Result: **0 leaks fixed** (no discard paths to guard).

## Dependency bumps

| Package | Old | New |
| --- | --- | --- |
| `@dcl/http-server` | `^2.0.2` (resolved 2.0.3) | `^2.1.0` (resolved 2.1.0) |

Other listed `@dcl` deps present in this repo were already at the latest authoritative versions and were left unchanged: `@dcl/metrics@^1.0.1`, `@dcl/pg-component@^0.2.0`, `@dcl/test-helpers@^0.2.0`. Non-listed `@dcl` deps (`@dcl/core-commons`, `@dcl/eslint-config`, `@dcl/protocol`) were not touched.

`yarn.lock` was refreshed with `yarn install` (yarn classic). `node_modules` is gitignored and not committed. The bump pulls in no transitive changes beyond the `http-server` entry itself (its `@dcl/core-commons 0.10.1` pin is unchanged).

## Verification

- Typecheck: `tsc --noEmit -p tsconfig.json` — passes (no errors).
- Lint: `eslint '**/*.{js,ts}'` — passes (no errors).
- Unit tests: `jest test/unit` — 11 suites, 83 tests, all passing.
- The single integration test (`test/integration/app.spec.ts`) boots the full app (including a real Postgres via `@dcl/pg-component`), which requires external infra not available here; it is left to CI.

No breaking changes were introduced by the bump.

Generated with Claude Code (https://claude.com/claude-code)
